### PR TITLE
Fix /dev/fd/63: line 76 in install.sh 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ fi
 
 
 install_base() {
-    if [[ "${release}" == "centos" ]]; then
+    if [[ "${release}" == "centos" ]] || [[ "${release}" == "fedora" ]] ; then
         yum install wget curl tar -y
     else
         apt install wget curl tar -y


### PR DESCRIPTION
Fix /dev/fd/63: line 76: apt: command not found in fedora