### PR TITLE
Fix ignore shortIds in Trojan reality link generator in subService.go

### DIFF
--- a/sub/subService.go
+++ b/sub/subService.go
@@ -539,7 +539,7 @@ func (s *SubService) genTrojanLink(inbound *model.Inbound, email string) string 
 			if pbkValue, ok := searchKey(realitySettings, "publicKey"); ok {
 				params["pbk"], _ = pbkValue.(string)
 			}
-			if sidValue, ok := searchKey(realitySettings, "shortIds"); ok {
+			if sidValue, ok := searchKey(realitySetting, "shortIds"); ok {
 				shortIds, _ := sidValue.([]interface{})
 				params["sid"], _ = shortIds[0].(string)
 			}


### PR DESCRIPTION
Fix ignore shortId in Trojan reality link generator in subService.go