### PR TITLE
Adding 'fakedns' to sniffing object in xray.js

### DIFF
--- a/web/assets/js/model/xray.js
+++ b/web/assets/js/model/xray.js
@@ -83,6 +83,7 @@ const SNIFFING_OPTION = {
     HTTP:    "http",
     TLS:     "tls",
     QUIC:    "quic",
+    FAKEDNS: "fakedns"
 };
 
 Object.freeze(Protocols);
@@ -754,7 +755,7 @@ class StreamSettings extends XrayCommonClass {
 }
 
 class Sniffing extends XrayCommonClass {
-    constructor(enabled=true, destOverride=['http', 'tls', 'quic']) {
+    constructor(enabled=true, destOverride=['http', 'tls', 'quic', 'fakedns']) {
         super();
         this.enabled = enabled;
         this.destOverride = destOverride;
@@ -764,7 +765,7 @@ class Sniffing extends XrayCommonClass {
         let destOverride = ObjectUtil.clone(json.destOverride);
         if (!ObjectUtil.isEmpty(destOverride) && !ObjectUtil.isArrEmpty(destOverride)) {
             if (ObjectUtil.isEmpty(destOverride[0])) {
-                destOverride = ['http', 'tls', 'quic'];
+                destOverride = ['http', 'tls', 'quic', 'fakedns'];
             }
         }
         return new Sniffing(


### PR DESCRIPTION
this option needed in order to use 'fakedns' .

based on below commits you did. it can be added to x-ui this way.

https://github.com/alireza0/x-ui/commit/700973655cf2a42ab36c7fbdf430287143a0c250 https://github.com/alireza0/x-ui/commit/dcb54267f28b917ee59155ac948b02c05e6215b0



