### PR TITLE
Bug Fix

### DIFF
--- a/web/html/xui/inbound_modal.html
+++ b/web/html/xui/inbound_modal.html
@@ -111,6 +111,11 @@
                 if (!inModal.inbound.canEnableReality()) {
                     this.inModal.inbound.reality = false;
                 }
+                if (this.inModal.inbound.protocol == Protocols.VLESS && !inModal.inbound.canEnableTlsFlow()) {
+                    this.inModal.inbound.settings.vlesses.forEach(client => {
+                        client.flow = "";
+                    });
+                }
             },
             setDefaultCertData(index){
                 inModal.inbound.stream.tls.certs[index].certFile = app.defaultCert;

--- a/web/html/xui/inbounds.html
+++ b/web/html/xui/inbounds.html
@@ -616,9 +616,17 @@
                     port: RandomUtil.randomIntRange(10000, 60000),
                     protocol: baseInbound.protocol,
                     settings: Inbound.Settings.getSettings(baseInbound.protocol).toString(),
-                    streamSettings: baseInbound.stream.toString(),
                     sniffing: baseInbound.canSniffing() ? baseInbound.sniffing.toString() : '{}',
                 };
+		if(baseInbound.stream.isReality) {
+                    const getNewX25519 = await HttpUtil.post('/server/getNewX25519Cert');
+                    baseInbound.stream.reality.shortIds = RandomUtil.randomShortId();
+                    baseInbound.stream.reality.privateKey = getNewX25519.obj.privateKey
+                    baseInbound.stream.reality.settings.publicKey = getNewX25519.obj.publicKey;
+                    data.streamSettings = baseInbound.stream.toString();
+                } else {
+                    data.streamSettings = baseInbound.stream.toString();
+                }
                 await this.submit('/xui/inbound/add', data, inModal);
             },
             async addInbound(inbound, dbInbound) {

--- a/web/html/xui/inbounds.html
+++ b/web/html/xui/inbounds.html
@@ -616,17 +616,9 @@
                     port: RandomUtil.randomIntRange(10000, 60000),
                     protocol: baseInbound.protocol,
                     settings: Inbound.Settings.getSettings(baseInbound.protocol).toString(),
+		    streamSettings: baseInbound.stream.toString(),
                     sniffing: baseInbound.canSniffing() ? baseInbound.sniffing.toString() : '{}',
                 };
-		if(baseInbound.stream.isReality) {
-                    const getNewX25519 = await HttpUtil.post('/server/getNewX25519Cert');
-                    baseInbound.stream.reality.shortIds = RandomUtil.randomShortId();
-                    baseInbound.stream.reality.privateKey = getNewX25519.obj.privateKey
-                    baseInbound.stream.reality.settings.publicKey = getNewX25519.obj.publicKey;
-                    data.streamSettings = baseInbound.stream.toString();
-                } else {
-                    data.streamSettings = baseInbound.stream.toString();
-                }
                 await this.submit('/xui/inbound/add', data, inModal);
             },
             async addInbound(inbound, dbInbound) {

--- a/web/service/xray.go
+++ b/web/service/xray.go
@@ -106,6 +106,13 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 
 			// clear client config for additional parameters
 			var final_clients []interface{}
+
+			// detect inbound transmission type
+			var stream map[string]interface{}
+			json.Unmarshal([]byte(inbound.StreamSettings), &stream)
+			network, _ := stream["network"].(string)
+			security, _ := stream["security"].(string)
+			
 			for _, client := range clients {
 
 				c := client.(map[string]interface{})
@@ -121,6 +128,9 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 					}
 					if c["flow"] == "xtls-rprx-vision-udp443" {
 						c["flow"] = "xtls-rprx-vision"
+					}
+					if network != "tcp" || !(security == "tls" || security == "reality") {
+						c["flow"] = ""
 					}
 				}
 				final_clients = append(final_clients, interface{}(c))

--- a/web/service/xray.go
+++ b/web/service/xray.go
@@ -106,13 +106,6 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 
 			// clear client config for additional parameters
 			var final_clients []interface{}
-
-			// detect inbound transmission type
-			var stream map[string]interface{}
-			json.Unmarshal([]byte(inbound.StreamSettings), &stream)
-			network, _ := stream["network"].(string)
-			security, _ := stream["security"].(string)
-			
 			for _, client := range clients {
 
 				c := client.(map[string]interface{})
@@ -128,9 +121,6 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 					}
 					if c["flow"] == "xtls-rprx-vision-udp443" {
 						c["flow"] = "xtls-rprx-vision"
-					}
-					if network != "tcp" || !(security == "tls" || security == "reality") {
-						c["flow"] = ""
 					}
 				}
 				final_clients = append(final_clients, interface{}(c))


### PR DESCRIPTION
Hello Again Alireza :)

Bug fix, can't connect after change transmission type from tcp to other types.
If flow is not equal to "" in transmission except tcp, connection will not be made. This problem occurs when we change the transmission from tcp to another type when editing inbound. Also, if tcp itself is alone and without tls and reality, flow must be empty in it.

This code monitors that tcp with tls or reality can only have flow.