### PR TITLE
change bootmortis project to MasterKia fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           rm -f Xray-linux-64.zip geoip.dat geosite.dat iran.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
-          wget https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/iran.dat
+          wget https://github.com/MasterKia/iran-hosted-domains/releases/latest/download/iran.dat
           mv xray xray-linux-amd64
           cd ..
           cd ..
@@ -72,7 +72,7 @@ jobs:
           rm -f Xray-linux-64.zip geoip.dat geosite.dat iran.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
-          wget https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/iran.dat
+          wget https://github.com/Masterkia/iran-hosted-domains/releases/latest/download/iran.dat
           mv xray xray-linux-arm64
           cd ..
           cd ..
@@ -113,7 +113,7 @@ jobs:
           rm -f Xray-linux-64.zip geoip.dat geosite.dat iran.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
-          wget https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/iran.dat
+          wget https://github.com/Masterkia/iran-hosted-domains/releases/latest/download/iran.dat
           mv xray xray-linux-s390x
           cd ..
           cd ..

--- a/DockerInitFiles.sh
+++ b/DockerInitFiles.sh
@@ -17,5 +17,5 @@ rm -f "Xray-linux-${ARCH}.zip" geoip.dat geosite.dat iran.dat
 mv xray "xray-linux-${FNAME}"
 wget "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat"
 wget "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat"
-wget "https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/iran.dat"
+wget "https://github.com/Masterkia/iran-hosted-domains/releases/latest/download/iran.dat"
 cd ../../


### PR DESCRIPTION
کامل ترین لیست سایت های تبلیغات ایرانی، پروژه https://github.com/MasterKia/PersianBlocker است که به صورت مستمر نیز آپدیت می‌شود. پروژه https://github.com/bootmortis/iran-hosted-domains هم از همین لیست استفاده می‌کرد. مدتی پیش bootmortis تصمیم گرفت منبع سایت تبلیغات خود را عوض کند، نه به این دلیل که لیست کامل‌تری وجود دارد، بلکه به دلیل اینکه پروژه PersianBlocker از لایسنس GPL استفاده میکرد و پروژه bootmortis/iran-hosted-domains از لایسنس MIT استفاده میکرد و نمی‌توانست بدون تغییر لایسنس از آن منبع استفاده کند. شرح کامل ماجرا: bootmortis/iran-hosted-domains#27
بعد از آن MasterKia پروژه iran-hosted-domains را با لایسنس GPL فورک کرد و لیست خود را که کامل تر بود را دوباره برگرداند. از این جهت که x-ui شما هم لایسنس GPL دارد و محدودیت استفاده از لیست کامل‌تر را ندارد، پیشنهاد می‌کنم پروژه https://github.com/MasterKia/iran-hosted-domains جایگزین https://github.com/bootmortis/iran-hosted-domains/ شود