### PR TITLE
Add wireguard to xray outbound

### DIFF
--- a/web/assets/js/model/outbound.js
+++ b/web/assets/js/model/outbound.js
@@ -920,8 +920,8 @@ Outbound.WireguardSettings = class extends CommonClass{
             json.DNS,
             json.secretKey,
             json.address.toString(),
-            peers[0].allowedIPs.toString(),
             peers[0].publicKey,
+            peers[0].allowedIPs.toString(),
             peers[0].endpoint,
         );
     }
@@ -939,4 +939,4 @@ Outbound.WireguardSettings = class extends CommonClass{
             }]
         };
     }
-}
+};

--- a/web/assets/js/model/outbound.js
+++ b/web/assets/js/model/outbound.js
@@ -8,6 +8,7 @@ const Protocols = {
     Shadowsocks: "shadowsocks",
     Socks: "socks",
     HTTP: "http",
+    Wireguard: "wireguard"
 };
 
 const SSMethods = {
@@ -625,6 +626,7 @@ Outbound.Settings = class extends CommonClass {
             case Protocols.Shadowsocks: return new Outbound.ShadowsocksSettings();
             case Protocols.Socks: return new Outbound.SocksSettings();
             case Protocols.HTTP: return new Outbound.HttpSettings();
+            case Protocols.Wireguard: return new Outbound.WireguardSettings();
             default: return null;
         }
     }
@@ -640,6 +642,7 @@ Outbound.Settings = class extends CommonClass {
             case Protocols.Shadowsocks: return Outbound.ShadowsocksSettings.fromJson(json);
             case Protocols.Socks: return Outbound.SocksSettings.fromJson(json);
             case Protocols.HTTP: return Outbound.HttpSettings.fromJson(json);
+            case Protocols.Wireguard: return Outbound.WireguardSettings.fromJson(json);
             default: return null;
         }
     }
@@ -898,3 +901,42 @@ Outbound.HttpSettings = class extends CommonClass {
         };
     }
 };
+Outbound.WireguardSettings = class extends CommonClass{
+    constructor(MTU, DNS, secretKey, address, publicKey, allowedIPs, endpoint) {
+        super();
+        this.MTU = MTU,
+        this.DNS = DNS,
+        this.secretKey = secretKey,
+        this.address = address,
+        this.publicKey= publicKey,
+        this.allowedIPs= allowedIPs,
+        this.endpoint = endpoint
+    }
+
+    static fromJson(json={}){
+        const peers = json.peers
+        return new Outbound.WireguardSettings(
+            json.MTU,
+            json.DNS,
+            json.secretKey,
+            json.address.toString(),
+            peers[0].allowedIPs.toString(),
+            peers[0].publicKey,
+            peers[0].endpoint,
+        );
+    }
+
+    toJson() {
+        return {
+            MTU: this.MTU,
+            DNS: this.DNS,
+            secretKey: this.secretKey,
+            address: this.address ? this.address.split(",") : [],
+            peers: [{
+                publicKey:this.publicKey,
+                allowedIPs: this.allowedIPs ? this.allowedIPs.split(",") : [],
+                endpoint: this.endpoint
+            }]
+        };
+    }
+}

--- a/web/assets/js/model/outbound.js
+++ b/web/assets/js/model/outbound.js
@@ -902,39 +902,39 @@ Outbound.HttpSettings = class extends CommonClass {
     }
 };
 Outbound.WireguardSettings = class extends CommonClass{
-    constructor(mtu=1280, dns='1.1.1.1', secretKey='', address='', publicKey='', allowedIPs='0.0.0.0/0,::/0', endpoint='') {
+    constructor(mtu=1420, secretKey='', address='', publicKey='', allowedIPs='0.0.0.0/0,::/0', endpoint='', keepAlive=0) {
         super();
         this.mtu = mtu,
-        this.dns = dns,
         this.secretKey = secretKey,
         this.address = address,
         this.publicKey = publicKey,
         this.allowedIPs = allowedIPs,
-        this.endpoint = endpoint
+        this.endpoint = endpoint,
+        this.keepAlive = keepAlive
     }
 
     static fromJson(json={}){
         const peers = json.peers
         return new Outbound.WireguardSettings(
             json.mtu,
-            json.dns,
             json.secretKey,
             json.address.toString(),
             peers[0].publicKey,
             peers[0].allowedIPs.toString(),
             peers[0].endpoint,
+            peers[0].keepAlive
         );
     }
 
     toJson() {
         return {
-            MTU: this.mtu,
-            DNS: this.dns,
+            mtu: this.mtu,
             secretKey: this.secretKey,
             address: this.address ? this.address.split(",") : [],
             peers: [{
                 publicKey:this.publicKey,
                 allowedIPs: this.allowedIPs ? this.allowedIPs.split(",") : [],
+                keepAlive: this.keepAlive,
                 endpoint: this.endpoint
             }]
         };

--- a/web/assets/js/model/outbound.js
+++ b/web/assets/js/model/outbound.js
@@ -902,22 +902,22 @@ Outbound.HttpSettings = class extends CommonClass {
     }
 };
 Outbound.WireguardSettings = class extends CommonClass{
-    constructor(MTU, DNS, secretKey, address, publicKey, allowedIPs, endpoint) {
+    constructor(mtu=1280, dns='1.1.1.1', secretKey='', address='', publicKey='', allowedIPs='0.0.0.0/0,::/0', endpoint='') {
         super();
-        this.MTU = MTU,
-        this.DNS = DNS,
+        this.mtu = mtu,
+        this.dns = dns,
         this.secretKey = secretKey,
         this.address = address,
-        this.publicKey= publicKey,
-        this.allowedIPs= allowedIPs,
+        this.publicKey = publicKey,
+        this.allowedIPs = allowedIPs,
         this.endpoint = endpoint
     }
 
     static fromJson(json={}){
         const peers = json.peers
         return new Outbound.WireguardSettings(
-            json.MTU,
-            json.DNS,
+            json.mtu,
+            json.dns,
             json.secretKey,
             json.address.toString(),
             peers[0].publicKey,
@@ -928,8 +928,8 @@ Outbound.WireguardSettings = class extends CommonClass{
 
     toJson() {
         return {
-            MTU: this.MTU,
-            DNS: this.DNS,
+            MTU: this.mtu,
+            DNS: this.dns,
             secretKey: this.secretKey,
             address: this.address ? this.address.split(",") : [],
             peers: [{

--- a/web/html/xui/form/outbound.html
+++ b/web/html/xui/form/outbound.html
@@ -66,6 +66,31 @@
         </a-form-item>
 </template>
 
+<!-- wireguard settings -->
+<template v-if="outbound.protocol === Protocols.Wireguard">
+    <a-form-item label='{{ i18n "pages.xray.outbound.MTU" }}'>
+        <a-input-number v-model.number="outbound.settings.MTU"></a-input-number>
+    </a-form-item>
+    <a-form-item label='{{ i18n "pages.xray.outbound.DNS" }}'>
+        <a-input v-model.trim="outbound.settings.DNS"></a-input>
+    </a-form-item>
+    <a-form-item label='{{ i18n "pages.xray.outbound.address" }}'>
+        <a-input v-model.trim="outbound.settings.address"></a-input>
+    </a-form-item>
+    <a-form-item label='{{ i18n "pages.xray.outbound.secretKey" }}'>
+        <a-input v-model.trim="outbound.settings.secretKey"></a-input>
+    </a-form-item>
+    <a-form-item label='{{ i18n "pages.xray.outbound.publicKey" }}'>
+        <a-input v-model.trim="outbound.settings.publicKey"></a-input>
+    </a-form-item>
+    <a-form-item label='{{ i18n "pages.xray.outbound.allowedIPs" }}'>
+        <a-input v-model.trim="outbound.settings.allowedIPs"></a-input>
+    </a-form-item>
+    <a-form-item label='{{ i18n "pages.xray.outbound.endpoint" }}'>
+        <a-input v-model.trim="outbound.settings.endpoint"></a-input>
+    </a-form-item>
+</template>
+
 <!-- Address + Port -->
 <template v-if="outbound.hasAddressPort()">
         <a-form-item label='{{ i18n "pages.inbounds.address" }}'>

--- a/web/html/xui/form/outbound.html
+++ b/web/html/xui/form/outbound.html
@@ -68,11 +68,11 @@
 
 <!-- wireguard settings -->
 <template v-if="outbound.protocol === Protocols.Wireguard">
-    <a-form-item label='{{ i18n "pages.xray.outbound.MTU" }}'>
-        <a-input-number v-model.number="outbound.settings.MTU"></a-input-number>
+    <a-form-item label='MTU'>
+        <a-input-number v-model.number="outbound.settings.mtu"></a-input-number>
     </a-form-item>
-    <a-form-item label='{{ i18n "pages.xray.outbound.DNS" }}'>
-        <a-input v-model.trim="outbound.settings.DNS"></a-input>
+    <a-form-item label='DNS'>
+        <a-input v-model.trim="outbound.settings.dns"></a-input>
     </a-form-item>
     <a-form-item label='{{ i18n "pages.xray.outbound.address" }}'>
         <a-input v-model.trim="outbound.settings.address"></a-input>

--- a/web/html/xui/form/outbound.html
+++ b/web/html/xui/form/outbound.html
@@ -71,9 +71,6 @@
     <a-form-item label='MTU'>
         <a-input-number v-model.number="outbound.settings.mtu"></a-input-number>
     </a-form-item>
-    <a-form-item label='DNS'>
-        <a-input v-model.trim="outbound.settings.dns"></a-input>
-    </a-form-item>
     <a-form-item label='{{ i18n "pages.xray.outbound.address" }}'>
         <a-input v-model.trim="outbound.settings.address"></a-input>
     </a-form-item>
@@ -85,6 +82,9 @@
     </a-form-item>
     <a-form-item label='{{ i18n "pages.xray.outbound.allowedIPs" }}'>
         <a-input v-model.trim="outbound.settings.allowedIPs"></a-input>
+    </a-form-item>
+    <a-form-item label='keepAlive'>
+        <a-input-number v-model.number="outbound.settings.keepAlive" :min="0"></a-input>
     </a-form-item>
     <a-form-item label='{{ i18n "pages.xray.outbound.endpoint" }}'>
         <a-input v-model.trim="outbound.settings.endpoint"></a-input>

--- a/web/translation/translate.en_US.toml
+++ b/web/translation/translate.en_US.toml
@@ -388,6 +388,12 @@
 "bridge" = "Bridge"
 "portal" = "Portal"
 "intercon" = "Interconnection"
+"MTU" = "MTU"
+"DNS" = "DNS"
+"secretKey" = "Secret Key"
+"publicKey" = "Public Key"
+"allowedIPs" = "Allowed IPs"
+"endpoint" = "End Point"
 
 [tgbot]
 "noResult" = "❗ No result!"

--- a/web/translation/translate.en_US.toml
+++ b/web/translation/translate.en_US.toml
@@ -388,8 +388,6 @@
 "bridge" = "Bridge"
 "portal" = "Portal"
 "intercon" = "Interconnection"
-"MTU" = "MTU"
-"DNS" = "DNS"
 "secretKey" = "Secret Key"
 "publicKey" = "Public Key"
 "allowedIPs" = "Allowed IPs"

--- a/web/translation/translate.fa_IR.toml
+++ b/web/translation/translate.fa_IR.toml
@@ -387,8 +387,6 @@
 "bridge" = "پل"
 "portal" = "پرتال"
 "intercon" = "اتصال میانی"
-"MTU" = "MTU"
-"DNS" = "DNS"
 "secretKey" = "کلید شخصی"
 "publicKey" = "کلید عمومی"
 "allowedIPs" = "های مجاز IP"

--- a/web/translation/translate.fa_IR.toml
+++ b/web/translation/translate.fa_IR.toml
@@ -387,6 +387,12 @@
 "bridge" = "پل"
 "portal" = "پرتال"
 "intercon" = "اتصال میانی"
+"MTU" = "MTU"
+"DNS" = "DNS"
+"secretKey" = "کلید شخصی"
+"publicKey" = "کلید عمومی"
+"allowedIPs" = "های مجاز IP"
+"endpoint" = "نقطه پایانی"
 
 [tgbot]
 "noResult" = "❗ نتیجه‌ای یافت نشد!"

--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -388,8 +388,6 @@
 "bridge" = "Мост"
 "portal" = "Портал"
 "intercon" = "Соединение"
-"MTU" = "МТУ"
-"DNS" = "DNS"
 "secretKey" = "Секретный ключ"
 "publicKey" = "Открытый ключ"
 "allowedIPs" = "Разрешенные IP-адреса"

--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -388,6 +388,12 @@
 "bridge" = "Мост"
 "portal" = "Портал"
 "intercon" = "Соединение"
+"MTU" = "МТУ"
+"DNS" = "DNS"
+"secretKey" = "Секретный ключ"
+"publicKey" = "Открытый ключ"
+"allowedIPs" = "Разрешенные IP-адреса"
+"endpoint" = "Конечная точка"
 
 [tgbot]
 "noResult" = "❗ Нет результатов!"

--- a/web/translation/translate.vi_VN.toml
+++ b/web/translation/translate.vi_VN.toml
@@ -388,6 +388,12 @@
 "bridge" = "Liên kết"
 "portal" = "Cổng thông tin"
 "intercon" = "Kết nối"
+"MTU" = "MTU"
+"DNS" = "DNS"
+"secretKey" = "Chìa khoá bí mật"
+"publicKey" = "Khóa công khai"
+"allowedIPs" = "IP được phép"
+"endpoint" = "Điểm cuối"
 
 [tgbot]
 "noResult" = "❗ Không có kết quả!"

--- a/web/translation/translate.vi_VN.toml
+++ b/web/translation/translate.vi_VN.toml
@@ -388,8 +388,6 @@
 "bridge" = "Liên kết"
 "portal" = "Cổng thông tin"
 "intercon" = "Kết nối"
-"MTU" = "MTU"
-"DNS" = "DNS"
 "secretKey" = "Chìa khoá bí mật"
 "publicKey" = "Khóa công khai"
 "allowedIPs" = "IP được phép"

--- a/web/translation/translate.zh_Hans.toml
+++ b/web/translation/translate.zh_Hans.toml
@@ -388,8 +388,6 @@
 "bridge" = "桥"
 "portal" = "门户"
 "intercon" = "互连"
-"MTU" = "最大传输单元"
-"DNS" = "域名系统"
 "secretKey" = "密钥"
 "publicKey" = "公钥"
 "allowedIPs" = "允许的 IP"

--- a/web/translation/translate.zh_Hans.toml
+++ b/web/translation/translate.zh_Hans.toml
@@ -388,6 +388,12 @@
 "bridge" = "桥"
 "portal" = "门户"
 "intercon" = "互连"
+"MTU" = "最大传输单元"
+"DNS" = "域名系统"
+"secretKey" = "密钥"
+"publicKey" = "公钥"
+"allowedIPs" = "允许的 IP"
+"endpoint" = "终点"
 
 [tgbot]
 "noResult" = "❗ 没有结果！"


### PR DESCRIPTION
Xray (1.6.5+) has added outbound WireGuard support. 
With this feature, we can use Warp or any WireGuard configuration in outbounds. I added the WireGuard template to x-ui to make it easier to use this feature.

<img width="402" alt="Screenshot 2023-12-14 130400" src="https://github.com/alireza0/x-ui/assets/79229394/8bfce908-51b9-4fec-ae9e-ce642e2f3a06">

<img width="402" alt="Screenshot 2023-12-14 130415" src="https://github.com/alireza0/x-ui/assets/79229394/3a39378e-c4d5-4056-86bf-547e8a9873b6">


Thank you for developing x-ui alireza ❤️