### PR TITLE
Fix "merging" of "Default" prompt with default value in `confirm()` function

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -60,7 +60,7 @@ fi
 
 confirm() {
     if [[ $# > 1 ]]; then
-        echo && read -p "$1 [Default$2]: " temp
+        echo && read -p "$1 [Default $2]: " temp
         if [[ x"${temp}" == x"" ]]; then
             temp=$2
         fi


### PR DESCRIPTION
Fix `Defaultn` -> `Default n` prompt "merging" in `confirm()` function

Before/After:
<img width="489" alt="image" src="https://github.com/alireza0/x-ui/assets/36568961/c0da0a4f-6542-494d-8a64-b2d5dce0cfe5">
