### PR TITLE
Update translate.zh_Hans.toml

### DIFF
--- a/web/translation/translate.zh_Hans.toml
+++ b/web/translation/translate.zh_Hans.toml
@@ -77,7 +77,7 @@
 "emptyUsername" = "请输入用户名"
 "emptyPassword" = "请输入密码"
 "wrongUsernameOrPassword" = "用户名或密码错误"
-"successLogin" = "登录成功"
+"successLogin" = "登录"
 
 [pages.index]
 "title" = "系统状态"


### PR DESCRIPTION
The original translation will result in a prompt of "登录成功成功" after successful login, and it is different from the translation in other languages