### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3"
 
 services:
   xui:


### PR DESCRIPTION
docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion