### PR TITLE
Address #1609 issue – added cron/cronie package install at dependency installation step

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,22 +41,22 @@ echo "arch: $(arch)"
 install_dependencies() {
     case "${release}" in
     ubuntu | debian | armbian)
-        apt-get update && apt-get install -y -q wget curl tar tzdata
+        apt-get update && apt-get install -y -q wget curl tar tzdata cron
         ;;
     centos | almalinux | rocky | ol)
-        yum -y update && yum install -y -q wget curl tar tzdata
+        yum -y update && yum install -y -q wget curl tar tzdata cronie
         ;;
     fedora | amzn)
-        dnf -y update && dnf install -y -q wget curl tar tzdata
+        dnf -y update && dnf install -y -q wget curl tar tzdata cronie
         ;;
     arch | manjaro | parch)
-        pacman -Syu && pacman -Syu --noconfirm wget curl tar tzdata
+        pacman -Syu && pacman -Syu --noconfirm wget curl tar tzdata cronie
         ;;
     opensuse-tumbleweed)
-        zypper refresh && zypper -q install -y wget curl tar timezone
+        zypper refresh && zypper -q install -y wget curl tar timezone cron
         ;;
     *)
-        apt-get update && apt install -y -q wget curl tar tzdata
+        apt-get update && apt install -y -q wget curl tar tzdata cron
         ;;
     esac
 }


### PR DESCRIPTION
To fix issue #1609 it is sufficient to install any package that provides the cron/crontab binary, as official [acme.sh](https://github.com/acmesh-official/acme.sh/blob/master/acme.sh) file. I think we can simply add this pkgs as a dependency and install it automatically

This patch does not fix the existing installation; I’ll add that later